### PR TITLE
Python wrapper

### DIFF
--- a/FMM/FMMWrapper.h
+++ b/FMM/FMMWrapper.h
@@ -37,7 +37,9 @@ class FMM_Wrapper {
     void FMM_SetBox(double, double, double, double, double, double);
 
   private:
+#ifdef FMMTIMING
     Timer myTimer;
+#endif
     double xlow, xhigh; // box
     double ylow, yhigh;
     double zlow, zhigh;

--- a/FMM/FMMWrapperWall2D.h
+++ b/FMM/FMMWrapperWall2D.h
@@ -37,7 +37,9 @@ class FMM_WrapperWall2D {
     void FMM_SetBox(double, double, double, double, double, double);
 
   private:
+#ifdef FMMTIMING
     Timer myTimer;
+#endif
     double xlow, xhigh; // box
     double ylow, yhigh;
     double zlow, zhigh;

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "FMM/FMMWrapper.h"
+#include "FMM/FMMWrapperWall2D.h"
 
 namespace p = boost::python;
 namespace np = boost::python::numpy;
@@ -58,6 +59,53 @@ void FMM_DataClear(FMM_Wrapper* fmm){
 }
 
 
+void FMMWall2D_SetBox(FMM_WrapperWall2D* fmm, double xlow, double xhigh, double ylow, double yhigh, double zlow, double zhigh){
+  fmm->FMM_SetBox(xlow, xhigh, ylow, yhigh, zlow, zhigh);
+}
+
+void FMMWall2D_UpdateTree(FMM_WrapperWall2D* fmm, np::ndarray trg_coord, np::ndarray src_coord){
+
+  // Transform ndarray to std::vectors
+  int num_trg = trg_coord.shape(0);
+  double * trg_iter = reinterpret_cast<double*>(trg_coord.get_data());
+  std::vector<double> trg_coord_vec(trg_iter, trg_iter + num_trg * 3);
+  int num_src = src_coord.shape(0);
+  double * src_iter = reinterpret_cast<double*>(src_coord.get_data());
+  std::vector<double> src_coord_vec(src_iter, src_iter + num_src * 3);
+  
+  // Call method
+  fmm->FMM_UpdateTree(src_coord_vec, trg_coord_vec);
+
+  return;
+}
+
+void FMMWall2D_Evaluate(FMM_WrapperWall2D* fmm, np::ndarray trg_value, np::ndarray src_value){
+
+  // Transform ndarray to std::vectors
+  int num_trg = trg_value.shape(0);
+  std::vector<double> trg_value_vec(num_trg * 3);
+  int num_src = src_value.shape(0);
+  double* src_iter = reinterpret_cast<double*>(src_value.get_data());
+  std::vector<double> src_value_vec(src_iter, src_iter + num_src * 3);
+
+  // Call method
+  fmm->FMM_Evaluate(trg_value_vec, num_trg, &src_value_vec);
+  
+  // Copy std::vector to ndarray
+  std::copy(trg_value_vec.begin(), trg_value_vec.end(), reinterpret_cast<double*>(trg_value.get_data()));
+
+  return;
+}
+
+void FMMWall2D_TreeClear(FMM_WrapperWall2D* fmm){
+  fmm->FMM_TreeClear();
+}
+
+void FMMWall2D_DataClear(FMM_WrapperWall2D* fmm){
+  fmm->FMM_DataClear();
+}
+
+
 BOOST_PYTHON_MODULE(periodic_fmm)
 {
   using namespace boost::python;
@@ -67,7 +115,7 @@ BOOST_PYTHON_MODULE(periodic_fmm)
   np::initialize();
 
   // Class FMM_Wrapper
-  enum_<FMM_Wrapper::PAXIS>("PAXIS")
+  enum_<FMM_Wrapper::PAXIS>("FMM_PAXIS")
     .value("NONE", FMM_Wrapper::NONE)
     .value("PX", FMM_Wrapper::PX)
     .value("PY", FMM_Wrapper::PY)
@@ -77,13 +125,27 @@ BOOST_PYTHON_MODULE(periodic_fmm)
     .value("PYZ", FMM_Wrapper::PYZ)
     .value("PXYZ", FMM_Wrapper::PXYZ);
   class_<FMM_Wrapper>("FMM_Wrapper", init<int, int, int, FMM_Wrapper::PAXIS>());
+
+  // Class FMM_WrapperWall2D
+  enum_<FMM_WrapperWall2D::PAXIS>("FMM_Wall2D_PAXIS")
+    .value("NONE", FMM_WrapperWall2D::NONE)
+    .value("PX", FMM_WrapperWall2D::PX)
+    .value("PXY", FMM_WrapperWall2D::PXY);
+  class_<FMM_WrapperWall2D>("FMM_WrapperWall2D", init<int, int, int, FMM_WrapperWall2D::PAXIS>());
   
-  // Define functions
+  // Define functions for FMM_Wrapper
   def("FMM_SetBox", FMM_SetBox);
   def("FMM_UpdateTree", FMM_UpdateTree);
   def("FMM_Evaluate", FMM_Evaluate);
   def("FMM_TreeClear", FMM_TreeClear);
   def("FMM_DataClear", FMM_DataClear);
+
+  // Define functions for FMMWall2D_Wrapper
+  def("FMMWall2D_SetBox", FMMWall2D_SetBox);
+  def("FMMWall2D_UpdateTree", FMMWall2D_UpdateTree);
+  def("FMMWall2D_Evaluate", FMMWall2D_Evaluate);
+  def("FMMWall2D_TreeClear", FMMWall2D_TreeClear);
+  def("FMMWall2D_DataClear", FMMWall2D_DataClear);
 }
 
 

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -5,14 +5,15 @@
 #include <math.h>
 #include <vector>
 
+#include "FMM/FMMWrapper.h"
 
 namespace bp = boost::python;
 namespace np = boost::python::numpy;
 
-void FMM(){
+void FMM(np::ndarray trg_coord){
 
-  //std::cout << "Hello from C++" << std::endl;
-  //std::cout << "Goodbye from C++" << std::endl;
+  std::cout << "Hello from C++" << std::endl;
+  std::cout << "Goodbye from C++" << std::endl;
   return;
 }
 
@@ -21,11 +22,12 @@ void FMM(){
 
 BOOST_PYTHON_MODULE(periodic_fmm)
 {
-  using namespace boost::python;
+  // using namespace boost::python;
+  // using namespace boost::python::numpy;
 
   // Initialize numpy
-  // Py_Initialize();
-  // np::initialize();
+  Py_Initialize();
+  np::initialize();
 
   // Definitions
   def("FMM", FMM);

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -1,0 +1,26 @@
+#include <boost/python.hpp>
+#include <stdio.h>
+#include <boost/python.hpp>
+#include <iostream>
+#include <math.h>
+#include <vector>
+
+
+namespace bp = boost::python;
+
+void FMM(){
+  std::cout << "Hello from C++" << std::endl;
+  
+  std::cout << "Goodbye from C++" << std::endl;
+  return;
+}
+
+
+
+
+BOOST_PYTHON_MODULE(periodic_fmm)
+{
+  using namespace boost::python;
+  // boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
+  def("FMM", FMM);
+}

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -6,57 +6,36 @@
 #include <vector>
 
 #include "FMM/FMMWrapper.h"
-#include "FMM/MiniFMM.h"
 
 namespace bp = boost::python;
 namespace np = boost::python::numpy;
 
-// typedef struct FMM_Wrapper FMM_Wrapper;
+void FMM_UpdateTree(FMM_Wrapper* fmm, np::ndarray trg_coord, np::ndarray src_coord){
+  std::cout << "Hello from FMM_UpdateTree" << std::endl;
 
+  // Transform ndarray to std::vectors
+  int ntrg = trg_coord.shape(0);
+  char* ctrg = trg_coord.get_data();
+  std::vector<double> vtrg(ctrg, ctrg + ntrg * 3);
+ 
+  int nsrc = src_coord.shape(0);
+  char* csrc = src_coord.get_data();
+  std::vector<double> vsrc(csrc, csrc + nsrc * 3);
 
-void FMM(np::ndarray trg_coord){
+  // Call method
+  fmm->FMM_UpdateTree(vsrc, vtrg);
 
-  std::cout << "Hello from C++" << std::endl;
-  std::cout << "Goodbye from C++" << std::endl;
   return;
 }
-
-
-
-
-
-
 
 
 BOOST_PYTHON_MODULE(periodic_fmm)
 {
   using namespace boost::python;
-  // using namespace boost::python::numpy;
-
+  
   // Initialize numpy
   Py_Initialize();
   np::initialize();
-
-  // Definitions
-  def("FMM", FMM);
-
-  // Class
-  // 
-  // enum_<Mini_FMM::PAXIS>("PAXIS")
-  // .value("NONE", Mini_FMM::NONE);
-
-  // Define Mock class
-  enum_<Mini_FMM::PAXIS>("Mini_PAXIS")
-    .value("NONE", Mini_FMM::NONE)
-    .value("PX", Mini_FMM::PX)
-    .value("PY", Mini_FMM::PY)
-    .value("PZ", Mini_FMM::PZ)
-    .value("PXY", Mini_FMM::PXY)
-    .value("PXZ", Mini_FMM::PXZ)
-    .value("PYZ", Mini_FMM::PYZ)
-    .value("PXYZ", Mini_FMM::PXYZ);
-  class_<Mini_FMM>("Mini_FMM", init<int, Mini_FMM::PAXIS>())
-    .def("saludo", &Mini_FMM::saludo);
 
   // Class FMM_Wrapper
   enum_<FMM_Wrapper::PAXIS>("PAXIS")
@@ -68,10 +47,16 @@ BOOST_PYTHON_MODULE(periodic_fmm)
     .value("PXZ", FMM_Wrapper::PXZ)
     .value("PYZ", FMM_Wrapper::PYZ)
     .value("PXYZ", FMM_Wrapper::PXYZ);
-  // FMM_Wrapper(int mult_order = 10, int max_pts = 2000, int init_depth = 0, PAXIS pbc_ = PAXIS::NONE);
-  class_<FMM_Wrapper>("FMM_Wrapper", init<int, int, int, FMM_Wrapper::PAXIS>());
-  // class_<FMM_Wrapper>("FMM_Wrapper");
-
+  class_<FMM_Wrapper>("FMM_Wrapper", init<int, int, int, FMM_Wrapper::PAXIS>())
+    .def("FMM_TreeClear", &FMM_Wrapper::FMM_TreeClear)
+    .def("FMM_DataClear", &FMM_Wrapper::FMM_DataClear)
+    .def("FMM_Evaluate", &FMM_Wrapper::FMM_Evaluate)
+    // .def("FMM_UpdateTree", &FMM_Wrapper::FMM_UpdateTree)
+    .def("FMM_SetBox", &FMM_Wrapper::FMM_SetBox)
+    ;
+  
+  // Define functions
+  def("FMM_UpdateTree", FMM_UpdateTree);
   
 }
 

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -6,9 +6,13 @@
 #include <vector>
 
 #include "FMM/FMMWrapper.h"
+#include "FMM/MiniFMM.h"
 
 namespace bp = boost::python;
 namespace np = boost::python::numpy;
+
+// typedef struct FMM_Wrapper FMM_Wrapper;
+
 
 void FMM(np::ndarray trg_coord){
 
@@ -20,9 +24,13 @@ void FMM(np::ndarray trg_coord){
 
 
 
+
+
+
+
 BOOST_PYTHON_MODULE(periodic_fmm)
 {
-  // using namespace boost::python;
+  using namespace boost::python;
   // using namespace boost::python::numpy;
 
   // Initialize numpy
@@ -31,4 +39,40 @@ BOOST_PYTHON_MODULE(periodic_fmm)
 
   // Definitions
   def("FMM", FMM);
+
+  // Class
+  // 
+  // enum_<Mini_FMM::PAXIS>("PAXIS")
+  // .value("NONE", Mini_FMM::NONE);
+
+  // Define Mock class
+  enum_<Mini_FMM::PAXIS>("Mini_PAXIS")
+    .value("NONE", Mini_FMM::NONE)
+    .value("PX", Mini_FMM::PX)
+    .value("PY", Mini_FMM::PY)
+    .value("PZ", Mini_FMM::PZ)
+    .value("PXY", Mini_FMM::PXY)
+    .value("PXZ", Mini_FMM::PXZ)
+    .value("PYZ", Mini_FMM::PYZ)
+    .value("PXYZ", Mini_FMM::PXYZ);
+  class_<Mini_FMM>("Mini_FMM", init<int, Mini_FMM::PAXIS>())
+    .def("saludo", &Mini_FMM::saludo);
+
+  // Class FMM_Wrapper
+  enum_<FMM_Wrapper::PAXIS>("PAXIS")
+    .value("NONE", FMM_Wrapper::NONE)
+    .value("PX", FMM_Wrapper::PX)
+    .value("PY", FMM_Wrapper::PY)
+    .value("PZ", FMM_Wrapper::PZ)
+    .value("PXY", FMM_Wrapper::PXY)
+    .value("PXZ", FMM_Wrapper::PXZ)
+    .value("PYZ", FMM_Wrapper::PYZ)
+    .value("PXYZ", FMM_Wrapper::PXYZ);
+  // FMM_Wrapper(int mult_order = 10, int max_pts = 2000, int init_depth = 0, PAXIS pbc_ = PAXIS::NONE);
+  class_<FMM_Wrapper>("FMM_Wrapper", init<int, int, int, FMM_Wrapper::PAXIS>());
+  // class_<FMM_Wrapper>("FMM_Wrapper");
+
+  
 }
+
+

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -1,17 +1,18 @@
 #include <boost/python.hpp>
+#include <boost/python/numpy.hpp>
 #include <stdio.h>
-#include <boost/python.hpp>
 #include <iostream>
 #include <math.h>
 #include <vector>
 
 
 namespace bp = boost::python;
+namespace np = boost::python::numpy;
 
 void FMM(){
-  std::cout << "Hello from C++" << std::endl;
-  
-  std::cout << "Goodbye from C++" << std::endl;
+
+  //std::cout << "Hello from C++" << std::endl;
+  //std::cout << "Goodbye from C++" << std::endl;
   return;
 }
 
@@ -21,6 +22,11 @@ void FMM(){
 BOOST_PYTHON_MODULE(periodic_fmm)
 {
   using namespace boost::python;
-  // boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
+
+  // Initialize numpy
+  // Py_Initialize();
+  // np::initialize();
+
+  // Definitions
   def("FMM", FMM);
 }

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -15,13 +15,12 @@ void FMM_UpdateTree(FMM_Wrapper* fmm, np::ndarray trg_coord, np::ndarray src_coo
 
   // Transform ndarray to std::vectors
   int ntrg = trg_coord.shape(0);
-  char* ctrg = trg_coord.get_data();
-  std::vector<double> vtrg(ctrg, ctrg + ntrg * 3);
- 
+  double * trg_iter = reinterpret_cast<double*>(trg_coord.get_data());
+  std::vector<double> vtrg(trg_iter, trg_iter + ntrg * 3);
   int nsrc = src_coord.shape(0);
-  char* csrc = src_coord.get_data();
-  std::vector<double> vsrc(csrc, csrc + nsrc * 3);
-
+  double * src_iter = reinterpret_cast<double*>(src_coord.get_data());
+  std::vector<double> vsrc(src_iter, src_iter + nsrc * 3);
+  
   // Call method
   fmm->FMM_UpdateTree(vsrc, vtrg);
 

--- a/Interface/FMMWrapper-py.cpp
+++ b/Interface/FMMWrapper-py.cpp
@@ -127,7 +127,7 @@ BOOST_PYTHON_MODULE(periodic_fmm)
   class_<FMM_Wrapper>("FMM_Wrapper", init<int, int, int, FMM_Wrapper::PAXIS>());
 
   // Class FMM_WrapperWall2D
-  enum_<FMM_WrapperWall2D::PAXIS>("FMM_Wall2D_PAXIS")
+  enum_<FMM_WrapperWall2D::PAXIS>("FMMWall2D_PAXIS")
     .value("NONE", FMM_WrapperWall2D::NONE)
     .value("PX", FMM_WrapperWall2D::PX)
     .value("PXY", FMM_WrapperWall2D::PXY);

--- a/ModuleTest/Python/Makefile
+++ b/ModuleTest/Python/Makefile
@@ -1,0 +1,43 @@
+include ../../MakefileInc.mk
+
+# location of the Python header files
+PYTHON_VERSION = 3.6m
+PYTHON_DIR = /mnt/home/fbalboausabiaga/.miniconda3
+PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-intel/include/python$(PYTHON_VERSION)/
+PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-intel/lib/
+
+
+# location of the Boost Python include files and library
+BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-intel/include
+BOOST_LIB = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-intel/lib
+
+# Define includes
+INCLUDE_DIRS = -I../../ -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
+
+CXX = mpiicpc
+CXXFLAGS += -fPIC 
+
+LINK := mpiicpc
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -Wl,-rpath=$(BOOST_LIB) -shared -L$(BOOST_LIB)  -lboost_python3 -lboost_numpy3 -lboost_system -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) 
+
+# Target and sources
+TARGET = periodic_fmm
+SRC = ../../Interface/FMMWrapper-py.cpp ../../FMM/FMMWrapper.cpp ../../FMM/FMMWrapperWall2D.cpp 
+INC = ../../FMM/FMMWrapper.h ../../FMM/FMMWrapperWall2D.h
+OBJ = ../../Interface/FMMWrapper-py.o ../../FMM/FMMWrapper.o ../../FMM/FMMWrapperWall2D.o
+
+# Link rule
+$(TARGET).so: $(OBJ)
+	$(LINK) $(OBJ) $(LINKFLAGS) -o $(TARGET).so  
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) $(INCLUDE_DIRS) -c $*.cpp -o $*.o
+
+# Individual dependencies
+$(OBJ): $(INC)
+
+
+clean: 
+	rm -f $(OBJ)
+	rm -f $(TARGET).so
+

--- a/ModuleTest/Python/Makefile.in
+++ b/ModuleTest/Python/Makefile.in
@@ -3,13 +3,13 @@ include ../../MakefileInc.mk
 # location of the Python header files
 PYTHON_VERSION = 3.6m
 PYTHON_DIR = /mnt/home/fbalboausabiaga/.miniconda3
-PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)/
-PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/
+PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-intel/include/python$(PYTHON_VERSION)/
+PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-intel/lib/
 
 
 # location of the Boost Python include files and library
-BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/include
-BOOST_LIB = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/lib
+BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-intel/include
+BOOST_LIB = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-intel/lib
 
 # Define includes
 INCLUDE_DIRS = -I../../ -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
@@ -18,12 +18,13 @@ CXX = mpiicpc
 CXXFLAGS += -fPIC 
 
 LINK := mpiicpc
-LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -Wl,-rpath=$(BOOST_LIB) -shared -L$(BOOST_LIB)  -lboost_python -lboost_numpy -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) 
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -Wl,-rpath=$(BOOST_LIB) -shared -L$(BOOST_LIB)  -lboost_python3 -lboost_numpy3 -lboost_system -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) 
 
 # Target and sources
 TARGET = periodic_fmm
-SRC = ../../Interface/FMMWrapper-py.cpp ../../FMM/FMMWrapper.cpp ../../FMM/MiniFMM.cpp
-OBJ = ../../Interface/FMMWrapper-py.o ../../FMM/FMMWrapper.o ../../FMM/MiniFMM.o
+SRC = ../../Interface/FMMWrapper-py.cpp ../../FMM/FMMWrapper.cpp ../../FMM/FMMWrapperWall2D.cpp 
+INC = ../../FMM/FMMWrapper.h ../../FMM/FMMWrapperWall2D.h
+OBJ = ../../Interface/FMMWrapper-py.o ../../FMM/FMMWrapper.o ../../FMM/FMMWrapperWall2D.o
 
 # Link rule
 $(TARGET).so: $(OBJ)

--- a/ModuleTest/Python/Makefile.in
+++ b/ModuleTest/Python/Makefile.in
@@ -1,33 +1,23 @@
-#
-# Compile with gcc-4.8.5? That was for visit
-#
+include ../../MakefileInc.mk
 
 # location of the Python header files
 PYTHON_VERSION = 3.6m
 PYTHON_DIR = /mnt/home/fbalboausabiaga/.miniconda3
-# PYTHON_INCLUDE = $(PYTHON_DIR)/include/python$(PYTHON_VERSION)m/
-# PYTHON_LIB = $(PYTHON_DIR)/lib/python$(PYTHON_VERSION)/config-3.6m-x86_64-linux-gnu/
-# PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py2.7/include/python$(PYTHON_VERSION)/
-# PYTHON_LIB = $(PYTHON_DIR)/envs/py2.7/lib/python$(PYTHON_VERSION)/config/
 PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)/
 PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/python$(PYTHON_VERSION)/config/
 
 # location of the Boost Python include files and library
-# BOOST_INC = /usr/include/boost
-# BOOST_LIB = /usr/lib64
-BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/include/boost
+BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/include
 BOOST_LIB = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/lib
 
 # Define includes
-INCLUDE_DIRS = -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
+INCLUDE_DIRS = -I../../ -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
 
-CXX = g++
+CXX = mpiicpc
 CXXFLAGS += -fPIC 
 
-# -lpython$(PYTHON_VERSION) 
-# -lpython3.6m
-LINK := g++
-LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -L$(BOOST_LIB) -L$(PYTHON_LIB) -shared -dynamiclib -lboost_python -lpython$(PYTHON_VERSION) -lboost_numpy
+LINK := mpiicpc
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -L$(BOOST_LIB) -L$(PYTHON_LIB) -shared  -lboost_python -lpython$(PYTHON_VERSION) -lboost_numpy
 
 # Target and source
 TARGET = periodic_fmm

--- a/ModuleTest/Python/Makefile.in
+++ b/ModuleTest/Python/Makefile.in
@@ -4,7 +4,8 @@ include ../../MakefileInc.mk
 PYTHON_VERSION = 3.6m
 PYTHON_DIR = /mnt/home/fbalboausabiaga/.miniconda3
 PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)/
-PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/python$(PYTHON_VERSION)/config/
+PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/
+
 
 # location of the Boost Python include files and library
 BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/include
@@ -17,9 +18,9 @@ CXX = mpiicpc
 CXXFLAGS += -fPIC 
 
 LINK := mpiicpc
-LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -L$(BOOST_LIB) -L$(PYTHON_LIB) -shared  -lboost_python -lpython$(PYTHON_VERSION) -lboost_numpy
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -Wl,-rpath=$(BOOST_LIB) -shared -L$(BOOST_LIB)  -lboost_python -lboost_numpy -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) 
 
-# Target and source
+# Target and sources
 TARGET = periodic_fmm
 SRC = ../../FMM/FMMWrapper-py.cpp
 

--- a/ModuleTest/Python/Makefile.in
+++ b/ModuleTest/Python/Makefile.in
@@ -1,0 +1,56 @@
+#
+# Compile with gcc-4.8.5? That was for visit
+#
+
+# location of the Python header files
+PYTHON_VERSION = 3.6m
+PYTHON_DIR = /mnt/home/fbalboausabiaga/.miniconda3
+# PYTHON_INCLUDE = $(PYTHON_DIR)/include/python$(PYTHON_VERSION)m/
+# PYTHON_LIB = $(PYTHON_DIR)/lib/python$(PYTHON_VERSION)/config-3.6m-x86_64-linux-gnu/
+# PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py2.7/include/python$(PYTHON_VERSION)/
+# PYTHON_LIB = $(PYTHON_DIR)/envs/py2.7/lib/python$(PYTHON_VERSION)/config/
+PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)/
+PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/python$(PYTHON_VERSION)/config/
+
+# location of the Boost Python include files and library
+# BOOST_INC = /usr/include/boost
+# BOOST_LIB = /usr/lib64
+BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/include/boost
+BOOST_LIB = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/lib
+
+# Define includes
+INCLUDE_DIRS = -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
+
+CXX = g++
+CXXFLAGS += -fPIC 
+
+# -lpython$(PYTHON_VERSION) 
+# -lpython3.6m
+LINK := g++
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -L$(BOOST_LIB) -L$(PYTHON_LIB) -shared -dynamiclib -lboost_python -lpython$(PYTHON_VERSION) -lboost_numpy
+
+# compile mesh classes
+TARGET = periodic_fmm
+
+SRC = ../../FMM/FMMWrapper-py.cpp
+
+# $(TARGET).so: $(TARGET).o
+#	g++ -shared  -dynamiclib $(TARGET).o -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) -o $(TARGET).so
+#	g++ -shared  -dynamiclib $(TARGET).o -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) -o $(TARGET).so
+
+# $(TARGET).o: $(TARGET).cc
+#	g++ -I$(PYTHON_INCLUDE) -I$(BOOST_INC) -fPIC -c $(TARGET).cc
+#	g++ -I$(PYTHON_INCLUDE) -I$(BOOST_INC) -fPIC -c visit_writer.c
+
+# Link rule
+$(TARGET).so: ../../Interface/FMMWrapper-py.o
+	$(CXX) $(LINKFLAGS) ../../Interface/FMMWrapper-py.o -o $(TARGET).so  
+
+# Compilation rules
+../../Interface/FMMWrapper-py.o: ../../Interface/FMMWrapper-py.cpp
+	$(CXX) $(INCLUDE_DIRS) $(CXXFLAGS)  -c ../../Interface/FMMWrapper-py.cpp -o ../../Interface/FMMWrapper-py.o
+
+
+clean: 
+	rm -f ../../Interface/FMMWrapper-py.o $(TARGET).so
+

--- a/ModuleTest/Python/Makefile.in
+++ b/ModuleTest/Python/Makefile.in
@@ -22,18 +22,21 @@ LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -Wl,-rpath=$(BOOST_LIB) -shared -L$
 
 # Target and sources
 TARGET = periodic_fmm
-SRC = ../../FMM/FMMWrapper-py.cpp
-
+SRC = ../../Interface/FMMWrapper-py.cpp ../../FMM/FMMWrapper.cpp ../../FMM/MiniFMM.cpp
+OBJ = ../../Interface/FMMWrapper-py.o ../../FMM/FMMWrapper.o ../../FMM/MiniFMM.o
 
 # Link rule
-$(TARGET).so: ../../Interface/FMMWrapper-py.o
-	$(CXX) ../../Interface/FMMWrapper-py.o $(LINKFLAGS) -o $(TARGET).so  
+$(TARGET).so: $(OBJ)
+	$(LINK) $(OBJ) $(LINKFLAGS) -o $(TARGET).so  
 
-# Compilation rules
-../../Interface/FMMWrapper-py.o: ../../Interface/FMMWrapper-py.cpp
-	$(CXX) $(INCLUDE_DIRS) $(CXXFLAGS)  -c ../../Interface/FMMWrapper-py.cpp -o ../../Interface/FMMWrapper-py.o
+.cpp.o:
+	$(CXX) $(CXXFLAGS) $(INCLUDE_DIRS) -c $*.cpp -o $*.o
+
+# Individual dependencies
+$(OBJ): $(INC)
 
 
 clean: 
-	rm -f ../../Interface/FMMWrapper-py.o $(TARGET).so
+	rm -f $(OBJ)
+	rm -f $(TARGET).so
 

--- a/ModuleTest/Python/Makefile.ubuntu
+++ b/ModuleTest/Python/Makefile.ubuntu
@@ -17,20 +17,25 @@ CXX = mpicxx
 CXXFLAGS += -fPIC 
 
 LINK := mpicxx
-LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -shared -dynamiclib -L$(BOOST_LIB) -lboost_python -lboost_numpy -lpython$(PYTHON_VERSION)
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -Wl,-rpath=$(BOOST_LIB) -shared -dynamiclib -L$(BOOST_LIB) -lboost_python -lboost_numpy -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) 
 
 # Target and sources
 TARGET = periodic_fmm
-SRC = ../../FMM/FMMWrapper-py.cpp
+SRC = ../../Interface/FMMWrapper-py.cpp ../../FMM/FMMWrapper.cpp 
+OBJ = ../../Interface/FMMWrapper-py.o ../../FMM/FMMWrapper.o 
 
 # Link rule
-$(TARGET).so: ../../Interface/FMMWrapper-py.o
-	$(CXX) ../../Interface/FMMWrapper-py.o $(LINKFLAGS) -o $(TARGET).so  
+$(TARGET).so: $(OBJ)
+	$(LINK) $(OBJ) $(LINKFLAGS) -o $(TARGET).so  
 
-# Compilation rules
-../../Interface/FMMWrapper-py.o: ../../Interface/FMMWrapper-py.cpp
-	$(CXX) $(INCLUDE_DIRS) $(CXXFLAGS)  -c ../../Interface/FMMWrapper-py.cpp -o ../../Interface/FMMWrapper-py.o
+.cpp.o:
+	$(CXX) $(CXXFLAGS) $(INCLUDE_DIRS) -c $*.cpp -o $*.o
+
+# Individual dependencies
+$(OBJ): $(INC)
+
 
 clean: 
-	rm -f ../../Interface/FMMWrapper-py.o $(TARGET).so
+	rm -f $(OBJ)
+	rm -f $(TARGET).so
 

--- a/ModuleTest/Python/Makefile.ubuntu
+++ b/ModuleTest/Python/Makefile.ubuntu
@@ -1,4 +1,4 @@
-# include ../../MakefileInc.mk
+include ../../MakefileInc.mk
 
 # location of the Python header files
 PYTHON_VERSION = 3.6
@@ -17,14 +17,14 @@ BOOST_INC = /home/fbalboausabiaga/.anaconda3/envs/py3.6-exp/include
 BOOST_LIB = /home/fbalboausabiaga/.anaconda3/envs/py3.6-exp/lib
 
 # Define includes
-INCLUDE_DIRS =  -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
+INCLUDE_DIRS = -I../../ -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
 
-CXX = g++
+CXX = mpic++
 CXXFLAGS += -fPIC 
 
 # -lpython$(PYTHON_VERSION) 
 # -lpython3.6m
-LINK := g++
+LINK := mpic++
 LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -shared -dynamiclib -L$(BOOST_LIB) -lboost_python -lboost_numpy -lpython3.6m 
 
 # compile mesh classes

--- a/ModuleTest/Python/Makefile.ubuntu
+++ b/ModuleTest/Python/Makefile.ubuntu
@@ -1,44 +1,27 @@
 include ../../MakefileInc.mk
 
 # location of the Python header files
-PYTHON_VERSION = 3.6
+PYTHON_VERSION = 3.6m
 PYTHON_DIR = /home/fbalboausabiaga/.anaconda3
-# PYTHON_INCLUDE = $(PYTHON_DIR)/include/python$(PYTHON_VERSION)m/
-# PYTHON_LIB = $(PYTHON_DIR)/lib/python$(PYTHON_VERSION)/config-3.6m-x86_64-linux-gnu/
-# PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py2.7/include/python$(PYTHON_VERSION)/
-# PYTHON_LIB = $(PYTHON_DIR)/envs/py2.7/lib/python$(PYTHON_VERSION)/config/
-PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)m/
+PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)/
 PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/
 
 # location of the Boost Python include files and library
-# BOOST_INC = /usr/include/boost
-# BOOST_LIB = /usr/lib64
 BOOST_INC = /home/fbalboausabiaga/.anaconda3/envs/py3.6-exp/include
 BOOST_LIB = /home/fbalboausabiaga/.anaconda3/envs/py3.6-exp/lib
 
 # Define includes
 INCLUDE_DIRS = -I../../ -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
 
-CXX = mpic++
+CXX = mpicxx
 CXXFLAGS += -fPIC 
 
-# -lpython$(PYTHON_VERSION) 
-# -lpython3.6m
-LINK := mpic++
-LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -shared -dynamiclib -L$(BOOST_LIB) -lboost_python -lboost_numpy -lpython3.6m 
+LINK := mpicxx
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -shared -dynamiclib -L$(BOOST_LIB) -lboost_python -lboost_numpy -lpython$(PYTHON_VERSION)
 
-# compile mesh classes
+# Target and sources
 TARGET = periodic_fmm
-
 SRC = ../../FMM/FMMWrapper-py.cpp
-
-# $(TARGET).so: $(TARGET).o
-#	g++ -shared  -dynamiclib $(TARGET).o -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) -o $(TARGET).so
-#	g++ -shared  -dynamiclib $(TARGET).o -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) -o $(TARGET).so
-
-# $(TARGET).o: $(TARGET).cc
-#	g++ -I$(PYTHON_INCLUDE) -I$(BOOST_INC) -fPIC -c $(TARGET).cc
-#	g++ -I$(PYTHON_INCLUDE) -I$(BOOST_INC) -fPIC -c visit_writer.c
 
 # Link rule
 $(TARGET).so: ../../Interface/FMMWrapper-py.o
@@ -47,7 +30,6 @@ $(TARGET).so: ../../Interface/FMMWrapper-py.o
 # Compilation rules
 ../../Interface/FMMWrapper-py.o: ../../Interface/FMMWrapper-py.cpp
 	$(CXX) $(INCLUDE_DIRS) $(CXXFLAGS)  -c ../../Interface/FMMWrapper-py.cpp -o ../../Interface/FMMWrapper-py.o
-
 
 clean: 
 	rm -f ../../Interface/FMMWrapper-py.o $(TARGET).so

--- a/ModuleTest/Python/Makefile.ubuntu
+++ b/ModuleTest/Python/Makefile.ubuntu
@@ -1,25 +1,23 @@
-#
-# Compile with gcc-4.8.5? That was for visit
-#
+# include ../../MakefileInc.mk
 
 # location of the Python header files
-PYTHON_VERSION = 3.6m
-PYTHON_DIR = /mnt/home/fbalboausabiaga/.miniconda3
+PYTHON_VERSION = 3.6
+PYTHON_DIR = /home/fbalboausabiaga/.anaconda3
 # PYTHON_INCLUDE = $(PYTHON_DIR)/include/python$(PYTHON_VERSION)m/
 # PYTHON_LIB = $(PYTHON_DIR)/lib/python$(PYTHON_VERSION)/config-3.6m-x86_64-linux-gnu/
 # PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py2.7/include/python$(PYTHON_VERSION)/
 # PYTHON_LIB = $(PYTHON_DIR)/envs/py2.7/lib/python$(PYTHON_VERSION)/config/
-PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)/
-PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/python$(PYTHON_VERSION)/config/
+PYTHON_INCLUDE = $(PYTHON_DIR)/envs/py3.6-exp/include/python$(PYTHON_VERSION)m/
+PYTHON_LIB = $(PYTHON_DIR)/envs/py3.6-exp/lib/
 
 # location of the Boost Python include files and library
 # BOOST_INC = /usr/include/boost
 # BOOST_LIB = /usr/lib64
-BOOST_INC = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/include/boost
-BOOST_LIB = /mnt/home/fbalboausabiaga/.miniconda3/envs/py3.6-exp/lib
+BOOST_INC = /home/fbalboausabiaga/.anaconda3/envs/py3.6-exp/include
+BOOST_LIB = /home/fbalboausabiaga/.anaconda3/envs/py3.6-exp/lib
 
 # Define includes
-INCLUDE_DIRS = -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
+INCLUDE_DIRS =  -I$(PYTHON_INCLUDE) -I$(BOOST_INC)
 
 CXX = g++
 CXXFLAGS += -fPIC 
@@ -27,12 +25,20 @@ CXXFLAGS += -fPIC
 # -lpython$(PYTHON_VERSION) 
 # -lpython3.6m
 LINK := g++
-LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -L$(BOOST_LIB) -L$(PYTHON_LIB) -shared -dynamiclib -lboost_python -lpython$(PYTHON_VERSION) -lboost_numpy
+LINKFLAGS := $(LINKFLAGS) -Wl,--no-undefined -shared -dynamiclib -L$(BOOST_LIB) -lboost_python -lboost_numpy -lpython3.6m 
 
-# Target and source
+# compile mesh classes
 TARGET = periodic_fmm
+
 SRC = ../../FMM/FMMWrapper-py.cpp
 
+# $(TARGET).so: $(TARGET).o
+#	g++ -shared  -dynamiclib $(TARGET).o -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) -o $(TARGET).so
+#	g++ -shared  -dynamiclib $(TARGET).o -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython$(PYTHON_VERSION) -o $(TARGET).so
+
+# $(TARGET).o: $(TARGET).cc
+#	g++ -I$(PYTHON_INCLUDE) -I$(BOOST_INC) -fPIC -c $(TARGET).cc
+#	g++ -I$(PYTHON_INCLUDE) -I$(BOOST_INC) -fPIC -c visit_writer.c
 
 # Link rule
 $(TARGET).so: ../../Interface/FMMWrapper-py.o

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -17,14 +17,16 @@ if __name__ == '__main__':
     mult_order = 10
     max_pts = 1024
     init_depth = 0
-    pbc = fmm.PAXIS.NONE
+    pbc = fmm.FMM_PAXIS.NONE
 
     # Create sources and targets
     nsrc = 1
     src_coord = np.random.rand(nsrc, 3)
+    src_coord[:,2] *= 0.1
     src_value = np.random.rand(nsrc, 3)
     ntrg = 2
     trg_coord = np.random.rand(ntrg, 3)
+    trg_coord[:,2] *= 0.1
     trg_value = np.zeros((ntrg, 3))
     
     # Set box dimensions
@@ -46,6 +48,7 @@ if __name__ == '__main__':
     print(src_coord)
 
     # Try FMM_Wrapper
+    print('\n\nTry FMM_Wrapper')
     myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
     fmm.FMM_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
     fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
@@ -55,10 +58,17 @@ if __name__ == '__main__':
     fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
     fmm.FMM_Evaluate(myFMM, trg_value, src_value)
 
-
-    print('Before end')
-
-
+    # Try FMM_WrapperWall2D
+    print('\n\nTry FMM_WrapperWall2D')
+    pbc = fmm.FMM_Wall2D_PAXIS.NONE
+    myFMM = fmm.FMM_WrapperWall2D(mult_order, max_pts, init_depth, pbc)
+    fmm.FMMWall2D_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
+    fmm.FMMWall2D_UpdateTree(myFMM, trg_coord, src_coord)
+    fmm.FMMWall2D_Evaluate(myFMM, trg_value, src_value)
+    fmm.FMMWall2D_DataClear(myFMM)
+    fmm.FMMWall2D_TreeClear(myFMM)
+    fmm.FMMWall2D_UpdateTree(myFMM, trg_coord, src_coord)
+    fmm.FMMWall2D_Evaluate(myFMM, trg_value, src_value)
 
     print('# End')
 

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -21,39 +21,43 @@ if __name__ == '__main__':
 
     # Create sources and targets
     nsrc = 1
-    src_coord = np.random.randn(nsrc, 3)
+    src_coord = np.random.rand(nsrc, 3)
+    src_value = np.random.rand(nsrc, 3)
     ntrg = 2
-    trg_coord = np.random.randn(ntrg, 3)
+    trg_coord = np.random.rand(ntrg, 3)
+    trg_value = np.zeros((ntrg, 3))
     
     # Set box dimensions
     box = np.zeros((2,3))
-    box[0,0] = np.minimum(src_coord[:,0].min(), trg_coord[:,0].min()) * 1.1
-    box[1,0] = np.maximum(src_coord[:,0].max(), trg_coord[:,0].max()) * 1.1
-
-    box[0,1] = np.minimum(src_coord[:,1].min(), trg_coord[:,1].min()) * 1.1
-    box[1,1] = np.maximum(src_coord[:,1].max(), trg_coord[:,1].max()) * 1.1
-
-    box[0,2] = np.minimum(src_coord[:,2].min(), trg_coord[:,2].min()) * 1.1
-    box[1,2] = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max()) * 1.1
-
-    # Try FMM_Wrapper
-    myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
+    m = np.minimum(src_coord[:,0].min(), trg_coord[:,0].min()) 
+    M = np.maximum(src_coord[:,0].max(), trg_coord[:,0].max()) 
+    box[0,0] = m - (M-m) * 0.1
+    box[1,0] = M + (M-m) * 0.1
+    m = np.minimum(src_coord[:,1].min(), trg_coord[:,1].min()) 
+    M = np.maximum(src_coord[:,1].max(), trg_coord[:,1].max()) 
+    box[0,1] = m - (M-m) * 0.1
+    box[1,1] = M + (M-m) * 0.1
+    m = np.minimum(src_coord[:,2].min(), trg_coord[:,2].min()) 
+    M = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max()) 
+    box[0,2] = m - (M-m) * 0.1
+    box[1,2] = M + (M-m) * 0.1
 
     print(trg_coord)
     print(src_coord)
-    print(box)
-    print('\n\n')
-    
-    myFMM.FMM_SetBox(box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
+
+    # Try FMM_Wrapper
+    myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
+    fmm.FMM_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
     fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
-    # myFMM.FMM_UpdateTree(trg_coord, src_coord);
-    # FMM_Evaluate(fmm, trgValue, srcValue, ntrg, nsrc);
-    # FMM_DataClear(fmm);
-    # FMM_Evaluate(fmm, trgValue, srcValue, ntrg, nsrc);
+    fmm.FMM_Evaluate(myFMM, trg_value, src_value)
+    fmm.FMM_DataClear(myFMM)
+    fmm.FMM_TreeClear(myFMM)
+    fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
+    fmm.FMM_Evaluate(myFMM, trg_value, src_value)
+
 
     print('Before end')
-    # fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
-    print('AAA')
+
 
 
     print('# End')

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -20,25 +20,30 @@ if __name__ == '__main__':
     pbc = fmm.PAXIS.NONE
 
     # Create sources and targets
-    nsrc = 10
+    nsrc = 1
     src_coord = np.random.randn(nsrc, 3)
-    ntrg = 10
+    ntrg = 2
     trg_coord = np.random.randn(ntrg, 3)
     
     # Set box dimensions
     box = np.zeros((2,3))
-    box[0,0] = np.minimum(src_coord[:,0].min(), trg_coord[:,0].min())
-    box[1,0] = np.maximum(src_coord[:,0].max(), trg_coord[:,0].max())
+    box[0,0] = np.minimum(src_coord[:,0].min(), trg_coord[:,0].min()) * 1.1
+    box[1,0] = np.maximum(src_coord[:,0].max(), trg_coord[:,0].max()) * 1.1
 
-    box[1,0] = np.minimum(src_coord[:,1].min(), trg_coord[:,1].min())
-    box[1,1] = np.maximum(src_coord[:,1].max(), trg_coord[:,1].max())
+    box[0,1] = np.minimum(src_coord[:,1].min(), trg_coord[:,1].min()) * 1.1
+    box[1,1] = np.maximum(src_coord[:,1].max(), trg_coord[:,1].max()) * 1.1
 
-    box[0,2] = np.minimum(src_coord[:,2].min(), trg_coord[:,2].min())
-    box[1,2] = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max())
+    box[0,2] = np.minimum(src_coord[:,2].min(), trg_coord[:,2].min()) * 1.1
+    box[1,2] = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max()) * 1.1
 
     # Try FMM_Wrapper
     myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
 
+    print(trg_coord)
+    print(src_coord)
+    print(box)
+    print('\n\n')
+    
     myFMM.FMM_SetBox(box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
     fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
     # myFMM.FMM_UpdateTree(trg_coord, src_coord);
@@ -47,7 +52,7 @@ if __name__ == '__main__':
     # FMM_Evaluate(fmm, trgValue, srcValue, ntrg, nsrc);
 
     print('Before end')
-    fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
+    # fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
     print('AAA')
 
 

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -3,7 +3,6 @@ import numpy as np
 import sys
 try:
     from mpi4py import MPI
-    print('MPI imported')
 except ImportError:
     print('It didn\'t find mpi4py!')
 
@@ -18,6 +17,10 @@ if __name__ == '__main__':
     max_pts = 1024
     init_depth = 0
     pbc = fmm.FMM_PAXIS.NONE
+
+    # Get MPI parameters
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
 
     # Create sources and targets
     nsrc = 1
@@ -43,12 +46,10 @@ if __name__ == '__main__':
     M = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max()) 
     box[0,2] = m - (M-m) * 0.1
     box[1,2] = M + (M-m) * 0.1
-
-    print(trg_coord)
-    print(src_coord)
+    sys.stdout.flush()
+    comm.Barrier()
 
     # Try FMM_Wrapper
-    print('\n\nTry FMM_Wrapper')
     myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
     fmm.FMM_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
     fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
@@ -59,7 +60,6 @@ if __name__ == '__main__':
     fmm.FMM_Evaluate(myFMM, trg_value, src_value)
 
     # Try FMM_WrapperWall2D
-    print('\n\nTry FMM_WrapperWall2D')
     pbc = fmm.FMM_Wall2D_PAXIS.NONE
     myFMM = fmm.FMM_WrapperWall2D(mult_order, max_pts, init_depth, pbc)
     fmm.FMMWall2D_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
@@ -70,5 +70,6 @@ if __name__ == '__main__':
     fmm.FMMWall2D_UpdateTree(myFMM, trg_coord, src_coord)
     fmm.FMMWall2D_Evaluate(myFMM, trg_value, src_value)
 
+    comm.Barrier()
     print('# End')
 

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     fmm.FMM_Evaluate(myFMM, trg_value, src_value)
 
     # Try FMM_WrapperWall2D
-    pbc = fmm.FMM_Wall2D_PAXIS.NONE
+    pbc = fmm.FMMWall2D_PAXIS.NONE
     myFMM = fmm.FMM_WrapperWall2D(mult_order, max_pts, init_depth, pbc)
     fmm.FMMWall2D_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
     fmm.FMMWall2D_UpdateTree(myFMM, trg_coord, src_coord)

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -3,9 +3,9 @@ import numpy as np
 import sys
 try:
     from mpi4py import MPI
+    print('MPI imported')
 except ImportError:
     print('It didn\'t find mpi4py!')
-
 
 import periodic_fmm as fmm
 
@@ -15,7 +15,40 @@ if __name__ == '__main__':
     ntrg = 10
     trg_coord = np.random.randn(ntrg, 3)
 
-    fmm.FMM(trg_coord)
+
+    if True:
+        # Try basic function
+        print('\n\n')
+        fmm.FMM(trg_coord)
+        
+    if True:
+        # Try Mini_FMM
+        print('\n\n')
+        print('xxx = ', fmm.Mini_PAXIS.PX)
+        Mini_FMM = fmm.Mini_FMM(10, fmm.Mini_PAXIS.NONE)
+        Mini_FMM.saludo()
+
+    if False:
+        # Test MPI
+        print('\n\n')
+        comm = MPI.COMM_WORLD
+        nprocs = comm.Get_size()
+        rank   = comm.Get_rank()
+
+        if rank == 0:
+            print('rank = ', rank)
+            data = 'Hello!'
+            comm.send(data, dest=nprocs-1, tag=1)
+        elif rank == nprocs-1:
+            data = comm.recv(source=0, tag=1)
+            print('rank ', rank, ' received ', data)
+
+
+    if True:
+        # Try FMM_Wrapper
+        print('\n\n')
+        myFMM = fmm.FMM_Wrapper(10, 1024, 0, fmm.PAXIS.NONE)
+
 
 
     print('# End')

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -16,42 +16,28 @@ if __name__ == '__main__':
     mult_order = 10
     max_pts = 1024
     init_depth = 0
-    pbc = fmm.FMM_PAXIS.NONE
 
     # Get MPI parameters
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
 
     # Create sources and targets
-    nsrc = 1
+    nsrc = 1024
     src_coord = np.random.rand(nsrc, 3)
     src_coord[:,2] *= 0.1
     src_value = np.random.rand(nsrc, 3)
-    ntrg = 2
+    ntrg = 1024
     trg_coord = np.random.rand(ntrg, 3)
     trg_coord[:,2] *= 0.1
     trg_value = np.zeros((ntrg, 3))
     
-    # Set box dimensions
-    box = np.zeros((2,3))
-    m = np.minimum(src_coord[:,0].min(), trg_coord[:,0].min()) 
-    M = np.maximum(src_coord[:,0].max(), trg_coord[:,0].max()) 
-    box[0,0] = m - (M-m) * 0.1
-    box[1,0] = M + (M-m) * 0.1
-    m = np.minimum(src_coord[:,1].min(), trg_coord[:,1].min()) 
-    M = np.maximum(src_coord[:,1].max(), trg_coord[:,1].max()) 
-    box[0,1] = m - (M-m) * 0.1
-    box[1,1] = M + (M-m) * 0.1
-    m = np.minimum(src_coord[:,2].min(), trg_coord[:,2].min()) 
-    M = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max()) 
-    box[0,2] = m - (M-m) * 0.1
-    box[1,2] = M + (M-m) * 0.1
     sys.stdout.flush()
     comm.Barrier()
 
     # Try FMM_Wrapper
+    pbc = fmm.FMM_PAXIS.NONE
     myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
-    fmm.FMM_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
+    fmm.FMM_SetBox(myFMM, -1.0, 1.0, -1.0, 1.0, 0.0, 2.0)
     fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
     fmm.FMM_Evaluate(myFMM, trg_value, src_value)
     fmm.FMM_DataClear(myFMM)
@@ -62,7 +48,7 @@ if __name__ == '__main__':
     # Try FMM_WrapperWall2D
     pbc = fmm.FMMWall2D_PAXIS.NONE
     myFMM = fmm.FMM_WrapperWall2D(mult_order, max_pts, init_depth, pbc)
-    fmm.FMMWall2D_SetBox(myFMM, box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
+    fmm.FMMWall2D_SetBox(myFMM, -2.0, 2.0, -2.0, 2.0, 0.0, 1.0)
     fmm.FMMWall2D_UpdateTree(myFMM, trg_coord, src_coord)
     fmm.FMMWall2D_Evaluate(myFMM, trg_value, src_value)
     fmm.FMMWall2D_DataClear(myFMM)

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -12,43 +12,43 @@ import periodic_fmm as fmm
 
 if __name__ == '__main__':
     print('# Start')
+
+    # FMM parameters
+    mult_order = 10
+    max_pts = 1024
+    init_depth = 0
+    pbc = fmm.PAXIS.NONE
+
+    # Create sources and targets
+    nsrc = 10
+    src_coord = np.random.randn(nsrc, 3)
     ntrg = 10
     trg_coord = np.random.randn(ntrg, 3)
+    
+    # Set box dimensions
+    box = np.zeros((2,3))
+    box[0,0] = np.minimum(src_coord[:,0].min(), trg_coord[:,0].min())
+    box[1,0] = np.maximum(src_coord[:,0].max(), trg_coord[:,0].max())
 
+    box[1,0] = np.minimum(src_coord[:,1].min(), trg_coord[:,1].min())
+    box[1,1] = np.maximum(src_coord[:,1].max(), trg_coord[:,1].max())
 
-    if True:
-        # Try basic function
-        print('\n\n')
-        fmm.FMM(trg_coord)
-        
-    if True:
-        # Try Mini_FMM
-        print('\n\n')
-        print('xxx = ', fmm.Mini_PAXIS.PX)
-        Mini_FMM = fmm.Mini_FMM(10, fmm.Mini_PAXIS.NONE)
-        Mini_FMM.saludo()
+    box[0,2] = np.minimum(src_coord[:,2].min(), trg_coord[:,2].min())
+    box[1,2] = np.maximum(src_coord[:,2].max(), trg_coord[:,2].max())
 
-    if False:
-        # Test MPI
-        print('\n\n')
-        comm = MPI.COMM_WORLD
-        nprocs = comm.Get_size()
-        rank   = comm.Get_rank()
+    # Try FMM_Wrapper
+    myFMM = fmm.FMM_Wrapper(mult_order, max_pts, init_depth, pbc)
 
-        if rank == 0:
-            print('rank = ', rank)
-            data = 'Hello!'
-            comm.send(data, dest=nprocs-1, tag=1)
-        elif rank == nprocs-1:
-            data = comm.recv(source=0, tag=1)
-            print('rank ', rank, ' received ', data)
+    myFMM.FMM_SetBox(box[0,0], box[1,0], box[0,1], box[1,1], box[0,2], box[1,2])
+    fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
+    # myFMM.FMM_UpdateTree(trg_coord, src_coord);
+    # FMM_Evaluate(fmm, trgValue, srcValue, ntrg, nsrc);
+    # FMM_DataClear(fmm);
+    # FMM_Evaluate(fmm, trgValue, srcValue, ntrg, nsrc);
 
-
-    if True:
-        # Try FMM_Wrapper
-        print('\n\n')
-        myFMM = fmm.FMM_Wrapper(10, 1024, 0, fmm.PAXIS.NONE)
-
+    print('Before end')
+    fmm.FMM_UpdateTree(myFMM, trg_coord, src_coord)
+    print('AAA')
 
 
     print('# End')

--- a/ModuleTest/Python/example.py
+++ b/ModuleTest/Python/example.py
@@ -1,0 +1,22 @@
+from __future__ import division, print_function
+import numpy as np
+import sys
+try:
+    from mpi4py import MPI
+except ImportError:
+    print('It didn\'t find mpi4py!')
+
+
+import periodic_fmm as fmm
+
+
+if __name__ == '__main__':
+    print('# Start')
+    ntrg = 10
+    trg_coord = np.random.randn(ntrg, 3)
+
+    fmm.FMM(trg_coord)
+
+
+    print('# End')
+


### PR DESCRIPTION
New main files:
Periodic/Interface/FMMWrapper-py.cpp
Periodic/ModuleTest/Python/example.py

New dependencies:
1. Boost (I use version 1.65.1).
2. mpi4py.

Comments:
I use the macro `FMMTIMING` to comment out the member `Timer myTimer` in the classes FMM_Wrapper and FMM_WrapperWall2D, otherwise I cannot compile the python wrapper.

